### PR TITLE
feat: Use dedicated port for webhook entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,18 @@ gitlab-ci-pipelines-exporter --gitlab.webhook-secret-token "GITLAB_SECRET_TOKEN"
 
 ```shell
 docker pull ghcr.io/radiofrance/gitlab-ci-pipelines-exporter
-docker run --publish 9252 ghcr.io/radiofrance/gitlab-ci-pipelines-exporter --gitlab.webhook-secret-token "GITLAB_SECRET_TOKEN"
+docker run --publish 8080 --publish 9252 ghcr.io/radiofrance/gitlab-ci-pipelines-exporter --gitlab.webhook-secret-token "GITLAB_SECRET_TOKEN"
 ```
 
 ### Helm
 
 ```shell
 helm repo add radiofrance-gcpe https://radiofrance.github.io/gitlab-ci-pipelines-exporter
-helm upgrade --install gitlab-ci-pipelines-exporter radiofrance-gcpe/gitlab-ci-pipelines-exporter --namespace gitlab-ci-pipelines-exporter --create-namespace --wait --set gitlab.webhook-secret-token="GITLAB_SECRET_TOKEN"
+helm upgrade --install gitlab-ci-pipelines-exporter radiofrance-gcpe/gitlab-ci-pipelines-exporter \
+  --namespace gitlab-ci-pipelines-exporter \
+  --create-namespace \
+  --wait \
+  --set gitlab.webhook-secret-token="GITLAB_SECRET_TOKEN"
 helm test gitlab-ci-pipelines-exporter --namespace gitlab-ci-pipelines-exporter
 ```
 
@@ -102,8 +106,9 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --web.listen-address value           address:port to listen on for telemetry (default: ":9252") [$WEB_LISTEN_ADDRESS]
-   --web.telemetry-path value           Path under which to expose metrics (default: "/metrics") [$WEB_TELEMETRY_PATH]
+   --web.listen-address value           address:port to listen on for incoming webhooks (default: ":8080") [$WEB_LISTEN_ADDRESS]
+   --telemetry.listen-address value     address:port to listen on for telemetry (default: ":9252") [$TELEMETRY_LISTEN_ADDRESS]
+   --telemetry.path value               Path under which to expose telemetry endpoint (default: "/metrics") [$TELEMETRY_PATH]
    --gitlab.webhook-secret-token token  token used to authenticate legitimate requests (overrides config file parameter) [$GITLAB_WEBHOOK_SECRET_TOKEN]
    --log.level value                    Log verbosity (default: "info") [$LOG_LEVEL]
    --help, -h                           show help (default: false)

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/urfave/cli/v2 v2.23.7 h1:YHDQ46s3VghFHFf1DdF+Sh7H4RqhcM+t0TmZRJx4oJY=
-github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/urfave/cli/v2 v2.24.1 h1:/QYYr7g0EhwXEML8jO+8OYt5trPnLHS0p3mrgExJ5NU=
 github.com/urfave/cli/v2 v2.24.1/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=

--- a/pkg/http/error.go
+++ b/pkg/http/error.go
@@ -1,9 +1,14 @@
-package webhook
+package http
 
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 )
+
+func WriteError(writer io.Writer, err any) {
+	_, _ = writer.Write(errToJson(err))
+}
 
 // errToJson convert anything into json object representing an error.
 func errToJson(err any) []byte {

--- a/pkg/http/error_test.go
+++ b/pkg/http/error_test.go
@@ -1,13 +1,15 @@
-package webhook
+package http_test
 
 import (
+	"bytes"
 	"net"
 	"testing"
 
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/http"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_errToJson(t *testing.T) {
+func Test_WriteError(t *testing.T) {
 	tcases := []struct {
 		err      any
 		expected string
@@ -19,6 +21,9 @@ func Test_errToJson(t *testing.T) {
 	}
 
 	for _, tcase := range tcases {
-		assert.Equal(t, tcase.expected, string(errToJson(tcase.err)))
+		var buf bytes.Buffer
+		http.WriteError(&buf, tcase.err)
+
+		assert.Equal(t, tcase.expected, buf.String())
 	}
 }

--- a/pkg/http/middlewares.go
+++ b/pkg/http/middlewares.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/urfave/negroni"
+	"go.uber.org/zap"
+)
+
+// NewZapMiddleware creates a negroni middleware to log every request.
+func NewZapMiddleware(logger *zap.Logger) negroni.Handler {
+	logger = logger.WithOptions(zap.WithCaller(false))
+	return negroni.HandlerFunc(func(writer http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		writer = negroni.NewResponseWriter(writer)
+
+		start := time.Now()
+		logger = logger.With(
+			zap.String("http_referer", req.Referer()),
+			zap.String("http_user_agent", req.UserAgent()),
+			zap.String("remote_addr", req.RemoteAddr),
+			zap.String("remote_user", req.Header.Get("X-Remote-User")),
+		)
+
+		next(writer, req)
+
+		logger = logger.With(
+			zap.Int("status", writer.(negroni.ResponseWriter).Status()),
+			zap.Int("body_bytes_sent", writer.(negroni.ResponseWriter).Size()),
+			zap.Float32("duration", float32(time.Since(start))/float32(time.Second)),
+		)
+
+		switch {
+		case writer.(negroni.ResponseWriter).Status() >= 500:
+			logger.Error(req.URL.String())
+		case writer.(negroni.ResponseWriter).Status() >= 400:
+			logger.Warn(req.URL.String())
+		default:
+			logger.Info(req.URL.String())
+		}
+	})
+}
+
+// NewRecoverMiddleware recovers from any panic and notify Gitlab through a 400.
+func NewRecoverMiddleware(logger *zap.Logger) negroni.Handler {
+	logger = logger.WithOptions(zap.AddStacktrace(zap.ErrorLevel))
+
+	return negroni.HandlerFunc(func(writer http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		defer func() {
+			if err := recover(); err != nil {
+				writer.WriteHeader(http.StatusInternalServerError)
+				WriteError(writer, err)
+
+				logger.Error("panic recovered", zap.String("error", fmt.Sprintf("%s", err)))
+			}
+		}()
+
+		next(writer, req)
+	})
+}

--- a/pkg/http/middlewares_test.go
+++ b/pkg/http/middlewares_test.go
@@ -1,0 +1,116 @@
+package http_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gcpehttp "github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestNewZapMiddleware(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	logger := zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+			LevelKey:       "L",
+			NameKey:        "N",
+			CallerKey:      "C",
+			FunctionKey:    zapcore.OmitKey,
+			MessageKey:     "M",
+			StacktraceKey:  "S",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
+			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		}),
+		zapcore.AddSync(buffer),
+		zap.InfoLevel,
+	))
+
+	next := http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) { writer.WriteHeader(http.StatusOK) })
+	mw := gcpehttp.NewZapMiddleware(logger)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://:::0", nil)
+	req.Header.Set("Referer", "go-test")
+	req.Header.Set("User-Agent", "go-test")
+	req.Header.Set("X-Remote-User", "go-test")
+	req.RemoteAddr = "127.0.0.1"
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req, next)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var log struct {
+		Level   string `json:"L"`
+		Message string `json:"M"`
+
+		BodyBytesSent int     `json:"body_bytes_sent"`
+		Duration      float32 `json:"duration"`
+		HttpReferer   string  `json:"http_referer"`
+		HttpUserAgent string  `json:"http_user_agent"`
+		RemoteAddr    string  `json:"remote_addr"`
+		RemoteUser    string  `json:"remote_user"`
+		Status        int     `json:"status"`
+		TimeLocal     string  `json:"time_local"`
+	}
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &log))
+	assert.Equal(t, "INFO", log.Level)
+	assert.Equal(t, "https://:::0", log.Message)
+
+	assert.Equal(t, 0, log.BodyBytesSent)
+	assert.Less(t, log.Duration*float32(time.Second), float32(time.Millisecond))
+	assert.Equal(t, "go-test", log.HttpReferer)
+	assert.Equal(t, "go-test", log.HttpUserAgent)
+	assert.Equal(t, "127.0.0.1", log.RemoteAddr)
+	assert.Equal(t, "go-test", log.RemoteUser)
+	assert.Equal(t, http.StatusOK, log.Status)
+}
+
+func TestNewRecoverMiddleware(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+	logger := zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+			LevelKey:       "L",
+			NameKey:        "N",
+			CallerKey:      "C",
+			FunctionKey:    zapcore.OmitKey,
+			MessageKey:     "M",
+			StacktraceKey:  "S",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		}),
+		zapcore.AddSync(buffer),
+		zap.InfoLevel,
+	))
+
+	next := http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) { panic("STONK !!!") })
+	mw := gcpehttp.NewRecoverMiddleware(logger)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://:::0", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req, next)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, `{"error":"STONK !!!"}`, w.Body.String())
+
+	var log struct {
+		Level      string `json:"L"`
+		Message    string `json:"M"`
+		StackTrace string `json:"S"`
+		Error      string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &log))
+	assert.Equal(t, "ERROR", log.Level)
+	assert.Equal(t, "panic recovered", log.Message)
+	assert.Equal(t, "STONK !!!", log.Error)
+	assert.NotEmpty(t, log.StackTrace)
+}

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -3,62 +3,33 @@ package metrics
 import (
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/collectors"
 	gcpehttp "github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/http"
 	"github.com/urfave/negroni"
 	"go.uber.org/zap"
 )
 
 type (
-	// Collectors groups all Prometheus collectors used to exporter Gitlab CI metrics.
-	Collectors struct {
-		IDCollector                       *prometheus.GaugeVec
-		DurationSecondsCollector          *prometheus.GaugeVec
-		QueuedDurationSecondsCollector    *prometheus.GaugeVec
-		RunCountCollector                 *prometheus.CounterVec
-		StatusCollector                   *prometheus.GaugeVec
-		TimestampCollector                *prometheus.GaugeVec
-		JobIDCollector                    *prometheus.GaugeVec
-		JobDurationSecondsCollector       *prometheus.GaugeVec
-		JobQueuedDurationSecondsCollector *prometheus.GaugeVec
-		JobRunCountCollector              *prometheus.CounterVec
-		JobStatusCollector                *prometheus.GaugeVec
-		JobTimestampCollector             *prometheus.GaugeVec
+	Collectors interface {
+		MustRegister()
 	}
 
 	Handler struct {
-		Collectors
-
-		mux *http.ServeMux
-		log *zap.Logger
+		collectors Collectors
+		mux        *http.ServeMux
+		log        *zap.Logger
 	}
 )
 
 // NewHandler creates a new instance of a Handler object.
 func NewHandler(pattern string, collectors Collectors, opts ...Option) *Handler {
 	handler := &Handler{
-		Collectors: collectors,
-
-		mux: http.NewServeMux(),
-		log: zap.Must(zap.NewProduction()),
+		collectors: collectors,
+		mux:        http.NewServeMux(),
+		log:        zap.Must(zap.NewProduction()),
 	}
 
-	prometheus.MustRegister(
-		handler.IDCollector,
-		handler.DurationSecondsCollector,
-		handler.QueuedDurationSecondsCollector,
-		handler.RunCountCollector,
-		handler.StatusCollector,
-		handler.TimestampCollector,
-		handler.JobIDCollector,
-		handler.JobDurationSecondsCollector,
-		handler.JobQueuedDurationSecondsCollector,
-		handler.JobRunCountCollector,
-		handler.JobStatusCollector,
-		handler.JobTimestampCollector,
-	)
+	collectors.MustRegister()
 
 	for _, opt := range opts {
 		opt(handler)
@@ -72,21 +43,4 @@ func NewHandler(pattern string, collectors Collectors, opts ...Option) *Handler 
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mux.ServeHTTP(w, r)
-}
-
-func AllCollectors() Collectors {
-	return Collectors{
-		IDCollector:                       collectors.NewCollectorID(),
-		DurationSecondsCollector:          collectors.NewCollectorDurationSeconds(),
-		QueuedDurationSecondsCollector:    collectors.NewCollectorQueuedDurationSeconds(),
-		RunCountCollector:                 collectors.NewCollectorRunCount(),
-		StatusCollector:                   collectors.NewCollectorStatus(),
-		TimestampCollector:                collectors.NewCollectorTimestamp(),
-		JobIDCollector:                    collectors.NewCollectorJobID(),
-		JobDurationSecondsCollector:       collectors.NewCollectorJobDurationSeconds(),
-		JobQueuedDurationSecondsCollector: collectors.NewCollectorJobQueuedDurationSeconds(),
-		JobRunCountCollector:              collectors.NewCollectorJobRunCount(),
-		JobStatusCollector:                collectors.NewCollectorJobStatus(),
-		JobTimestampCollector:             collectors.NewCollectorJobTimestamp(),
-	}
 }

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -1,0 +1,92 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/collectors"
+	gcpehttp "github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/http"
+	"github.com/urfave/negroni"
+	"go.uber.org/zap"
+)
+
+type (
+	// Collectors groups all Prometheus collectors used to exporter Gitlab CI metrics.
+	Collectors struct {
+		IDCollector                       *prometheus.GaugeVec
+		DurationSecondsCollector          *prometheus.GaugeVec
+		QueuedDurationSecondsCollector    *prometheus.GaugeVec
+		RunCountCollector                 *prometheus.CounterVec
+		StatusCollector                   *prometheus.GaugeVec
+		TimestampCollector                *prometheus.GaugeVec
+		JobIDCollector                    *prometheus.GaugeVec
+		JobDurationSecondsCollector       *prometheus.GaugeVec
+		JobQueuedDurationSecondsCollector *prometheus.GaugeVec
+		JobRunCountCollector              *prometheus.CounterVec
+		JobStatusCollector                *prometheus.GaugeVec
+		JobTimestampCollector             *prometheus.GaugeVec
+	}
+
+	Handler struct {
+		Collectors
+
+		mux *http.ServeMux
+		log *zap.Logger
+	}
+)
+
+// NewHandler creates a new instance of a Handler object.
+func NewHandler(pattern string, collectors Collectors, opts ...Option) *Handler {
+	handler := &Handler{
+		Collectors: collectors,
+
+		mux: http.NewServeMux(),
+		log: zap.Must(zap.NewProduction()),
+	}
+
+	prometheus.MustRegister(
+		handler.IDCollector,
+		handler.DurationSecondsCollector,
+		handler.QueuedDurationSecondsCollector,
+		handler.RunCountCollector,
+		handler.StatusCollector,
+		handler.TimestampCollector,
+		handler.JobIDCollector,
+		handler.JobDurationSecondsCollector,
+		handler.JobQueuedDurationSecondsCollector,
+		handler.JobRunCountCollector,
+		handler.JobStatusCollector,
+		handler.JobTimestampCollector,
+	)
+
+	for _, opt := range opts {
+		opt(handler)
+	}
+
+	root := negroni.New(gcpehttp.NewRecoverMiddleware(handler.log), gcpehttp.NewZapMiddleware(handler.log))
+	handler.mux.Handle(pattern, root.With(negroni.Wrap(promhttp.Handler())))
+
+	return handler
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mux.ServeHTTP(w, r)
+}
+
+func AllCollectors() Collectors {
+	return Collectors{
+		IDCollector:                       collectors.NewCollectorID(),
+		DurationSecondsCollector:          collectors.NewCollectorDurationSeconds(),
+		QueuedDurationSecondsCollector:    collectors.NewCollectorQueuedDurationSeconds(),
+		RunCountCollector:                 collectors.NewCollectorRunCount(),
+		StatusCollector:                   collectors.NewCollectorStatus(),
+		TimestampCollector:                collectors.NewCollectorTimestamp(),
+		JobIDCollector:                    collectors.NewCollectorJobID(),
+		JobDurationSecondsCollector:       collectors.NewCollectorJobDurationSeconds(),
+		JobQueuedDurationSecondsCollector: collectors.NewCollectorJobQueuedDurationSeconds(),
+		JobRunCountCollector:              collectors.NewCollectorJobRunCount(),
+		JobStatusCollector:                collectors.NewCollectorJobStatus(),
+		JobTimestampCollector:             collectors.NewCollectorJobTimestamp(),
+	}
+}

--- a/pkg/metrics/handler_test.go
+++ b/pkg/metrics/handler_test.go
@@ -1,0 +1,48 @@
+package metrics_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCollectors struct{}
+
+func (c fakeCollectors) MustRegister() {
+	fakeMetric := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fake_total",
+			Help: "A fake counter metric",
+		},
+		[]string{"label"},
+	)
+	fakeMetric.With(prometheus.Labels{"label": "value"}).Inc()
+
+	prometheus.MustRegister(fakeMetric)
+}
+
+func Test_Handler_ServeHTTP(t *testing.T) {
+	collectors := &fakeCollectors{}
+	handler := metrics.NewHandler("/metrics", collectors)
+	server := httptest.NewServer(handler)
+
+	response, err := server.Client().Get(fmt.Sprintf("%s/metrics", server.URL))
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	expectedBody := `# HELP fake_total A fake counter metric
+# TYPE fake_total counter
+fake_total{label="value"} 1
+`
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Contains(t, string(body), expectedBody)
+}

--- a/pkg/metrics/opts.go
+++ b/pkg/metrics/opts.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "go.uber.org/zap"
+
+type (
+	Option func(webhook *Handler)
+)
+
+// WithZapLogger configures the webhook with a preconfigured zap instance.
+func WithZapLogger(logger *zap.Logger) Option {
+	return func(handler *Handler) {
+		if logger != nil {
+			handler.log = logger
+		}
+	}
+}

--- a/pkg/metrics/opts_test.go
+++ b/pkg/metrics/opts_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestWithZapLogger(t *testing.T) {
 	logger := zap.NewNop()
-	handler := NewHandler("/metrics", AllCollectors(), WithZapLogger(logger))
+	handler := NewHandler("/metrics", NewPrometheusCollectors(), WithZapLogger(logger))
 	assert.Equal(t, logger, handler.log)
 }

--- a/pkg/metrics/opts_test.go
+++ b/pkg/metrics/opts_test.go
@@ -1,4 +1,4 @@
-package webhook
+package metrics
 
 import (
 	"testing"
@@ -9,6 +9,6 @@ import (
 
 func TestWithZapLogger(t *testing.T) {
 	logger := zap.NewNop()
-	webhook := NewWebhook("", WithZapLogger(logger))
-	assert.Equal(t, logger, webhook.log)
+	handler := NewHandler("/metrics", AllCollectors(), WithZapLogger(logger))
+	assert.Equal(t, logger, handler.log)
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/collectors"
+)
+
+// PrometheusCollectors groups all Prometheus collectors used to exporter Gitlab CI metrics.
+type PrometheusCollectors struct {
+	ID                       *prometheus.GaugeVec
+	DurationSeconds          *prometheus.GaugeVec
+	QueuedDurationSeconds    *prometheus.GaugeVec
+	RunCount                 *prometheus.CounterVec
+	Status                   *prometheus.GaugeVec
+	Timestamp                *prometheus.GaugeVec
+	JobID                    *prometheus.GaugeVec
+	JobDurationSeconds       *prometheus.GaugeVec
+	JobQueuedDurationSeconds *prometheus.GaugeVec
+	JobRunCount              *prometheus.CounterVec
+	JobStatus                *prometheus.GaugeVec
+	JobTimestamp             *prometheus.GaugeVec
+}
+
+// NewPrometheusCollectors creates a new PrometheusCollectors instance.
+func NewPrometheusCollectors() *PrometheusCollectors {
+	return &PrometheusCollectors{
+		ID:                       collectors.NewCollectorID(),
+		DurationSeconds:          collectors.NewCollectorDurationSeconds(),
+		QueuedDurationSeconds:    collectors.NewCollectorQueuedDurationSeconds(),
+		RunCount:                 collectors.NewCollectorRunCount(),
+		Status:                   collectors.NewCollectorStatus(),
+		Timestamp:                collectors.NewCollectorTimestamp(),
+		JobID:                    collectors.NewCollectorJobID(),
+		JobDurationSeconds:       collectors.NewCollectorJobDurationSeconds(),
+		JobQueuedDurationSeconds: collectors.NewCollectorJobQueuedDurationSeconds(),
+		JobRunCount:              collectors.NewCollectorJobRunCount(),
+		JobStatus:                collectors.NewCollectorJobStatus(),
+		JobTimestamp:             collectors.NewCollectorJobTimestamp(),
+	}
+}
+
+// MustRegister registers the Prometheus collectors and panics if any error occurs.
+func (c PrometheusCollectors) MustRegister() {
+	prometheus.MustRegister(
+		c.ID,
+		c.DurationSeconds,
+		c.QueuedDurationSeconds,
+		c.RunCount,
+		c.Status,
+		c.Timestamp,
+		c.JobID,
+		c.JobDurationSeconds,
+		c.JobQueuedDurationSeconds,
+		c.JobRunCount,
+		c.JobStatus,
+		c.JobTimestamp,
+	)
+}

--- a/pkg/webhook/handlers.go
+++ b/pkg/webhook/handlers.go
@@ -22,23 +22,23 @@ func (w Webhook) handlePipelineEvent(event gitlab_events.PipelineEvent) error {
 	project, ref, kind := event.ProjectName(), event.Ref(), event.RefKind()
 	labels := prometheus.Labels{"project": project, "ref": ref, "kind": kind.String()}
 
-	w.IDCollector.With(labels).Set(float64(event.ObjectAttributes.ID))
-	w.TimestampCollector.With(labels).Set(timestamp())
+	w.collectors.ID.With(labels).Set(float64(event.ObjectAttributes.ID))
+	w.collectors.Timestamp.With(labels).Set(timestamp())
 
 	if event.ObjectAttributes.QueuedDuration.IsSome() {
-		w.QueuedDurationSecondsCollector.With(labels).Set(event.ObjectAttributes.QueuedDuration.Unwrap())
+		w.collectors.QueuedDurationSeconds.With(labels).Set(event.ObjectAttributes.QueuedDuration.Unwrap())
 	}
 	if event.ObjectAttributes.Duration.IsSome() {
-		w.DurationSecondsCollector.With(labels).Set(event.ObjectAttributes.Duration.Unwrap())
+		w.collectors.DurationSeconds.With(labels).Set(event.ObjectAttributes.Duration.Unwrap())
 	}
 
 	if event.ObjectAttributes.Status == gitlab_events.Running {
-		w.RunCountCollector.With(labels).Inc()
+		w.collectors.RunCount.With(labels).Inc()
 	}
 
 	for _, status := range gitlab_events.Statuses[1:] {
 		labels["status"] = status
-		w.StatusCollector.With(labels).Set(btof[event.ObjectAttributes.Status.String() == status])
+		w.collectors.Status.With(labels).Set(btof[event.ObjectAttributes.Status.String() == status])
 	}
 	return nil
 }
@@ -52,23 +52,23 @@ func (w Webhook) handleJobEvent(event gitlab_events.JobEvent) error {
 		"stage": stage, "job_name": job,
 	}
 
-	w.JobIDCollector.With(labels).Set(float64(event.BuildID))
-	w.JobTimestampCollector.With(labels).Set(timestamp())
+	w.collectors.JobID.With(labels).Set(float64(event.BuildID))
+	w.collectors.JobTimestamp.With(labels).Set(timestamp())
 
 	if event.BuildQueuedDuration.IsSome() {
-		w.JobQueuedDurationSecondsCollector.With(labels).Set(event.BuildQueuedDuration.Unwrap())
+		w.collectors.JobQueuedDurationSeconds.With(labels).Set(event.BuildQueuedDuration.Unwrap())
 	}
 	if event.BuildDuration.IsSome() {
-		w.JobDurationSecondsCollector.With(labels).Set(event.BuildDuration.Unwrap())
+		w.collectors.JobDurationSeconds.With(labels).Set(event.BuildDuration.Unwrap())
 	}
 
 	if event.BuildStatus == gitlab_events.Running {
-		w.JobRunCountCollector.With(labels).Inc()
+		w.collectors.JobRunCount.With(labels).Inc()
 	}
 
 	for _, status := range gitlab_events.Statuses[1:] {
 		labels["status"] = status
-		w.JobStatusCollector.With(labels).Set(btof[event.BuildStatus.String() == status])
+		w.collectors.JobStatus.With(labels).Set(btof[event.BuildStatus.String() == status])
 	}
 	return nil
 }

--- a/pkg/webhook/handlers_test.go
+++ b/pkg/webhook/handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/collectors"
 	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,15 +26,8 @@ func (suite *PipelineHandlerTestSuite) SetupSuite() {
 
 func (suite *PipelineHandlerTestSuite) SetupTest() {
 	suite.webhook = &Webhook{
-		Collectors: metrics.Collectors{
-			IDCollector:                    collectors.NewCollectorID(),
-			DurationSecondsCollector:       collectors.NewCollectorDurationSeconds(),
-			QueuedDurationSecondsCollector: collectors.NewCollectorQueuedDurationSeconds(),
-			RunCountCollector:              collectors.NewCollectorRunCount(),
-			StatusCollector:                collectors.NewCollectorStatus(),
-			TimestampCollector:             collectors.NewCollectorTimestamp(),
-		},
-		log: zap.NewNop(),
+		collectors: metrics.NewPrometheusCollectors(),
+		log:        zap.NewNop(),
 	}
 }
 
@@ -48,20 +40,20 @@ func (suite *PipelineHandlerTestSuite) TestSingleEvent() {
 		},
 
 		map[prometheus.Collector]string{
-			suite.webhook.IDCollector: `
+			suite.webhook.collectors.ID: `
 # HELP gitlab_ci_pipeline_id ID of the most recent pipeline
 # TYPE gitlab_ci_pipeline_id gauge
 gitlab_ci_pipeline_id{kind="merge_request",project="radiofrance/gitlab-ci-pipelines-exporter",ref="9832"} 4223
 `,
-			suite.webhook.TimestampCollector: `
+			suite.webhook.collectors.Timestamp: `
 # HELP gitlab_ci_pipeline_timestamp Timestamp of the last update of the most recent pipeline
 # TYPE gitlab_ci_pipeline_timestamp gauge
 gitlab_ci_pipeline_timestamp{kind="merge_request",project="radiofrance/gitlab-ci-pipelines-exporter",ref="9832"} 0
 `,
-			suite.webhook.QueuedDurationSecondsCollector: ``,
-			suite.webhook.DurationSecondsCollector:       ``,
-			suite.webhook.RunCountCollector:              ``,
-			suite.webhook.StatusCollector: `
+			suite.webhook.collectors.QueuedDurationSeconds: ``,
+			suite.webhook.collectors.DurationSeconds:       ``,
+			suite.webhook.collectors.RunCount:              ``,
+			suite.webhook.collectors.Status: `
 # HELP gitlab_ci_pipeline_status Status of the most recent pipeline
 # TYPE gitlab_ci_pipeline_status gauge
 gitlab_ci_pipeline_status{kind="merge_request",project="radiofrance/gitlab-ci-pipelines-exporter",ref="9832",status="canceled"} 0
@@ -95,34 +87,34 @@ func (suite *PipelineHandlerTestSuite) TestMultipleEvents() {
 		},
 
 		map[prometheus.Collector]string{
-			suite.webhook.IDCollector: `
+			suite.webhook.collectors.ID: `
 # HELP gitlab_ci_pipeline_id ID of the most recent pipeline
 # TYPE gitlab_ci_pipeline_id gauge
 gitlab_ci_pipeline_id{kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master"} 4228
 gitlab_ci_pipeline_id{kind="tag",project="radiofrance/gitlab-ci-pipelines-exporter",ref="v1.0.0"} 4229
 `,
-			suite.webhook.TimestampCollector: `
+			suite.webhook.collectors.Timestamp: `
 # HELP gitlab_ci_pipeline_timestamp Timestamp of the last update of the most recent pipeline
 # TYPE gitlab_ci_pipeline_timestamp gauge
 gitlab_ci_pipeline_timestamp{kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master"} 0
 gitlab_ci_pipeline_timestamp{kind="tag",project="radiofrance/gitlab-ci-pipelines-exporter",ref="v1.0.0"} 0
 `,
-			suite.webhook.QueuedDurationSecondsCollector: `
+			suite.webhook.collectors.QueuedDurationSeconds: `
 # HELP gitlab_ci_pipeline_queued_duration_seconds Duration in seconds the most recent pipeline has been queued before starting
 # TYPE gitlab_ci_pipeline_queued_duration_seconds gauge
 gitlab_ci_pipeline_queued_duration_seconds{kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master"} 2.343087599
 `,
-			suite.webhook.DurationSecondsCollector: `
+			suite.webhook.collectors.DurationSeconds: `
 # HELP gitlab_ci_pipeline_duration_seconds Duration in seconds of the most recent pipeline
 # TYPE gitlab_ci_pipeline_duration_seconds gauge
 gitlab_ci_pipeline_duration_seconds{kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master"} 91.140114
 `,
-			suite.webhook.RunCountCollector: `
+			suite.webhook.collectors.RunCount: `
 # HELP gitlab_ci_pipeline_run_count Number of executions of a pipeline
 # TYPE gitlab_ci_pipeline_run_count counter
 gitlab_ci_pipeline_run_count{kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master"} 2
 `,
-			suite.webhook.StatusCollector: `
+			suite.webhook.collectors.Status: `
 # HELP gitlab_ci_pipeline_status Status of the most recent pipeline
 # TYPE gitlab_ci_pipeline_status gauge
 gitlab_ci_pipeline_status{kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",status="canceled"} 0
@@ -167,15 +159,8 @@ func (suite *JobHandlerTestSuite) SetupSuite() {
 
 func (suite *JobHandlerTestSuite) SetupTest() {
 	suite.webhook = &Webhook{
-		Collectors: metrics.Collectors{
-			JobIDCollector:                    collectors.NewCollectorJobID(),
-			JobDurationSecondsCollector:       collectors.NewCollectorJobDurationSeconds(),
-			JobQueuedDurationSecondsCollector: collectors.NewCollectorJobQueuedDurationSeconds(),
-			JobRunCountCollector:              collectors.NewCollectorJobRunCount(),
-			JobStatusCollector:                collectors.NewCollectorJobStatus(),
-			JobTimestampCollector:             collectors.NewCollectorJobTimestamp(),
-		},
-		log: zap.NewNop(),
+		collectors: metrics.NewPrometheusCollectors(),
+		log:        zap.NewNop(),
 	}
 }
 
@@ -186,20 +171,20 @@ func (suite *JobHandlerTestSuite) TestSingleEvent() {
 			`{"ref":"refs/merge-requests/9832/merge","build_id":0,"build_name":"golang-ci-lint","build_stage":"quality","build_status":"created","project_name":"radiofrance / gitlab-ci-pipelines-exporter"}`,
 		},
 		map[prometheus.Collector]string{
-			suite.webhook.JobIDCollector: `
+			suite.webhook.collectors.JobID: `
 # HELP gitlab_ci_pipeline_job_id ID of the most recent job
 # TYPE gitlab_ci_pipeline_job_id gauge
 gitlab_ci_pipeline_job_id{job_name="golang-ci-lint",kind="merge_request",project="radiofrance/gitlab-ci-pipelines-exporter",ref="9832",stage="quality"} 0
 `,
-			suite.webhook.JobTimestampCollector: `
+			suite.webhook.collectors.JobTimestamp: `
 # HELP gitlab_ci_pipeline_job_timestamp Creation date timestamp of the the most recent job
 # TYPE gitlab_ci_pipeline_job_timestamp gauge
 gitlab_ci_pipeline_job_timestamp{job_name="golang-ci-lint",kind="merge_request",project="radiofrance/gitlab-ci-pipelines-exporter",ref="9832",stage="quality"} 0
 `,
-			suite.webhook.JobDurationSecondsCollector:       ``,
-			suite.webhook.JobQueuedDurationSecondsCollector: ``,
-			suite.webhook.JobRunCountCollector:              ``,
-			suite.webhook.JobStatusCollector: `
+			suite.webhook.collectors.JobDurationSeconds:       ``,
+			suite.webhook.collectors.JobQueuedDurationSeconds: ``,
+			suite.webhook.collectors.JobRunCount:              ``,
+			suite.webhook.collectors.JobStatus: `
 # HELP gitlab_ci_pipeline_job_status Status of the most recent job
 # TYPE gitlab_ci_pipeline_job_status gauge
 gitlab_ci_pipeline_job_status{job_name="golang-ci-lint",kind="merge_request",project="radiofrance/gitlab-ci-pipelines-exporter",ref="9832",stage="quality",status="canceled"} 0
@@ -231,34 +216,34 @@ func (suite *JobHandlerTestSuite) TestMultipleEvents() {
 			`{"ref":"master","build_id":4235,"build_name":"build-image","build_stage":"build","build_status":"created","project_name":"radiofrance / gitlab-ci-pipelines-exporter"}`,
 		},
 		map[prometheus.Collector]string{
-			suite.webhook.JobIDCollector: `
+			suite.webhook.collectors.JobID: `
 # HELP gitlab_ci_pipeline_job_id ID of the most recent job
 # TYPE gitlab_ci_pipeline_job_id gauge
 gitlab_ci_pipeline_job_id{job_name="build-image",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="build"} 4235
 gitlab_ci_pipeline_job_id{job_name="golang-ci-lint",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="quality"} 4234
 `,
-			suite.webhook.JobTimestampCollector: `
+			suite.webhook.collectors.JobTimestamp: `
 # HELP gitlab_ci_pipeline_job_timestamp Creation date timestamp of the the most recent job
 # TYPE gitlab_ci_pipeline_job_timestamp gauge
 gitlab_ci_pipeline_job_timestamp{job_name="build-image",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="build"} 0
 gitlab_ci_pipeline_job_timestamp{job_name="golang-ci-lint",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="quality"} 0
 `,
-			suite.webhook.JobDurationSecondsCollector: `
+			suite.webhook.collectors.JobDurationSeconds: `
 # HELP gitlab_ci_pipeline_job_duration_seconds Duration in seconds of the most recent job
 # TYPE gitlab_ci_pipeline_job_duration_seconds gauge
 gitlab_ci_pipeline_job_duration_seconds{job_name="golang-ci-lint",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="quality"} 196.868193
 `,
-			suite.webhook.JobQueuedDurationSecondsCollector: `
+			suite.webhook.collectors.JobQueuedDurationSeconds: `
 # HELP gitlab_ci_pipeline_job_queued_duration_seconds Duration in seconds the most recent job has been queued before starting
 # TYPE gitlab_ci_pipeline_job_queued_duration_seconds gauge
 gitlab_ci_pipeline_job_queued_duration_seconds{job_name="golang-ci-lint",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="quality"} 0.074549967
 `,
-			suite.webhook.JobRunCountCollector: `
+			suite.webhook.collectors.JobRunCount: `
 # HELP gitlab_ci_pipeline_job_run_count Number of executions of a job
 # TYPE gitlab_ci_pipeline_job_run_count counter
 gitlab_ci_pipeline_job_run_count{job_name="golang-ci-lint",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="quality"} 2
 `,
-			suite.webhook.JobStatusCollector: `
+			suite.webhook.collectors.JobStatus: `
 # HELP gitlab_ci_pipeline_job_status Status of the most recent job
 # TYPE gitlab_ci_pipeline_job_status gauge
 gitlab_ci_pipeline_job_status{job_name="build-image",kind="branch",project="radiofrance/gitlab-ci-pipelines-exporter",ref="master",stage="build",status="canceled"} 0

--- a/pkg/webhook/handlers_test.go
+++ b/pkg/webhook/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/collectors"
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -26,7 +27,7 @@ func (suite *PipelineHandlerTestSuite) SetupSuite() {
 
 func (suite *PipelineHandlerTestSuite) SetupTest() {
 	suite.webhook = &Webhook{
-		Collectors: Collectors{
+		Collectors: metrics.Collectors{
 			IDCollector:                    collectors.NewCollectorID(),
 			DurationSecondsCollector:       collectors.NewCollectorDurationSeconds(),
 			QueuedDurationSecondsCollector: collectors.NewCollectorQueuedDurationSeconds(),
@@ -166,7 +167,7 @@ func (suite *JobHandlerTestSuite) SetupSuite() {
 
 func (suite *JobHandlerTestSuite) SetupTest() {
 	suite.webhook = &Webhook{
-		Collectors: Collectors{
+		Collectors: metrics.Collectors{
 			JobIDCollector:                    collectors.NewCollectorJobID(),
 			JobDurationSecondsCollector:       collectors.NewCollectorJobDurationSeconds(),
 			JobQueuedDurationSecondsCollector: collectors.NewCollectorJobQueuedDurationSeconds(),

--- a/pkg/webhook/middlewares.go
+++ b/pkg/webhook/middlewares.go
@@ -1,46 +1,11 @@
 package webhook
 
 import (
-	"fmt"
 	"net/http"
-	"time"
 
+	gcpehttp "github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/http"
 	"github.com/urfave/negroni"
-	"go.uber.org/zap"
 )
-
-// NewZapMiddleware creates a negroni middleware to log every request.
-func NewZapMiddleware(logger *zap.Logger) negroni.Handler {
-	logger = logger.WithOptions(zap.WithCaller(false))
-	return negroni.HandlerFunc(func(writer http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-		writer = negroni.NewResponseWriter(writer)
-
-		start := time.Now()
-		logger = logger.With(
-			zap.String("http_referer", req.Referer()),
-			zap.String("http_user_agent", req.UserAgent()),
-			zap.String("remote_addr", req.RemoteAddr),
-			zap.String("remote_user", req.Header.Get("X-Remote-User")),
-		)
-
-		next(writer, req)
-
-		logger = logger.With(
-			zap.Int("status", writer.(negroni.ResponseWriter).Status()),
-			zap.Int("body_bytes_sent", writer.(negroni.ResponseWriter).Size()),
-			zap.Float32("duration", float32(time.Since(start))/float32(time.Second)),
-		)
-
-		switch {
-		case writer.(negroni.ResponseWriter).Status() >= 500:
-			logger.Error(req.URL.String())
-		case writer.(negroni.ResponseWriter).Status() >= 400:
-			logger.Warn(req.URL.String())
-		default:
-			logger.Info(req.URL.String())
-		}
-	})
-}
 
 // NewGitlabSecretTokenMiddleware rejects all requests using the wrong Gitlab secret token.
 func NewGitlabSecretTokenMiddleware(token string) negroni.Handler {
@@ -51,27 +16,9 @@ func NewGitlabSecretTokenMiddleware(token string) negroni.Handler {
 			//			 https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#configure-your-webhook-receiver-endpoint
 			//			 for more details.
 			writer.WriteHeader(http.StatusInternalServerError)
-			_, _ = writer.Write(errToJson("invalid Gitlab webhook secret token"))
+			gcpehttp.WriteError(writer, "invalid Gitlab webhook secret token")
 			return
 		}
-
-		next(writer, req)
-	})
-}
-
-// NewRecoverMiddleware recovers from any panic and notify Gitlab through a 400.
-func NewRecoverMiddleware(logger *zap.Logger) negroni.Handler {
-	logger = logger.WithOptions(zap.AddStacktrace(zap.ErrorLevel))
-
-	return negroni.HandlerFunc(func(writer http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-		defer func() {
-			if err := recover(); err != nil {
-				writer.WriteHeader(http.StatusInternalServerError)
-				_, _ = writer.Write(errToJson(err))
-
-				logger.Error("panic recovered", zap.String("error", fmt.Sprintf("%s", err)))
-			}
-		}()
 
 		next(writer, req)
 	})

--- a/pkg/webhook/middlewares_test.go
+++ b/pkg/webhook/middlewares_test.go
@@ -1,80 +1,17 @@
-package webhook
+package webhook_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/webhook"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
-
-func TestNewZapMiddleware(t *testing.T) {
-	buffer := bytes.NewBuffer(nil)
-	logger := zap.New(zapcore.NewCore(
-		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
-			LevelKey:       "L",
-			NameKey:        "N",
-			CallerKey:      "C",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "M",
-			StacktraceKey:  "S",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
-			EncodeLevel:    zapcore.CapitalLevelEncoder,
-			EncodeDuration: zapcore.StringDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		}),
-		zapcore.AddSync(buffer),
-		zap.InfoLevel,
-	))
-
-	next := http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) { writer.WriteHeader(http.StatusOK) })
-	mw := NewZapMiddleware(logger)
-
-	req, _ := http.NewRequest(http.MethodPost, "https://:::0", nil)
-	req.Header.Set("Referer", "go-test")
-	req.Header.Set("User-Agent", "go-test")
-	req.Header.Set("X-Remote-User", "go-test")
-	req.RemoteAddr = "127.0.0.1"
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, req, next)
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	var log struct {
-		Level   string `json:"L"`
-		Message string `json:"M"`
-
-		BodyBytesSent int     `json:"body_bytes_sent"`
-		Duration      float32 `json:"duration"`
-		HttpReferer   string  `json:"http_referer"`
-		HttpUserAgent string  `json:"http_user_agent"`
-		RemoteAddr    string  `json:"remote_addr"`
-		RemoteUser    string  `json:"remote_user"`
-		Status        int     `json:"status"`
-		TimeLocal     string  `json:"time_local"`
-	}
-	require.NoError(t, json.Unmarshal(buffer.Bytes(), &log))
-	assert.Equal(t, "INFO", log.Level)
-	assert.Equal(t, "https://:::0", log.Message)
-
-	assert.Equal(t, 0, log.BodyBytesSent)
-	assert.Less(t, log.Duration*float32(time.Second), float32(time.Millisecond))
-	assert.Equal(t, "go-test", log.HttpReferer)
-	assert.Equal(t, "go-test", log.HttpUserAgent)
-	assert.Equal(t, "127.0.0.1", log.RemoteAddr)
-	assert.Equal(t, "go-test", log.RemoteUser)
-	assert.Equal(t, http.StatusOK, log.Status)
-}
 
 func TestNewGitlabSecretTokenMiddleware(t *testing.T) {
 	next := http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) { writer.WriteHeader(http.StatusOK) })
-	mw := NewGitlabSecretTokenMiddleware("token")
+	mw := webhook.NewGitlabSecretTokenMiddleware("token")
 
 	req, _ := http.NewRequest(http.MethodPost, "https://:::0", nil)
 	w := httptest.NewRecorder()
@@ -86,46 +23,4 @@ func TestNewGitlabSecretTokenMiddleware(t *testing.T) {
 	w = httptest.NewRecorder()
 	mw.ServeHTTP(w, req, next)
 	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestNewRecoverMiddleware(t *testing.T) {
-	buffer := bytes.NewBuffer(nil)
-	logger := zap.New(zapcore.NewCore(
-		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
-			LevelKey:       "L",
-			NameKey:        "N",
-			CallerKey:      "C",
-			FunctionKey:    zapcore.OmitKey,
-			MessageKey:     "M",
-			StacktraceKey:  "S",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.CapitalLevelEncoder,
-			EncodeDuration: zapcore.StringDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		}),
-		zapcore.AddSync(buffer),
-		zap.InfoLevel,
-	))
-
-	next := http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) { panic("STONK !!!") })
-	mw := NewRecoverMiddleware(logger)
-
-	req, _ := http.NewRequest(http.MethodPost, "https://:::0", nil)
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, req, next)
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Equal(t, `{"error":"STONK !!!"}`, w.Body.String())
-
-	var log struct {
-		Level      string `json:"L"`
-		Message    string `json:"M"`
-		StackTrace string `json:"S"`
-		Error      string `json:"error"`
-	}
-	require.NoError(t, json.Unmarshal(buffer.Bytes(), &log))
-	assert.Equal(t, "ERROR", log.Level)
-	assert.Equal(t, "panic recovered", log.Message)
-	assert.Equal(t, "STONK !!!", log.Error)
-	assert.NotEmpty(t, log.StackTrace)
 }

--- a/pkg/webhook/opts_test.go
+++ b/pkg/webhook/opts_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestWithZapLogger(t *testing.T) {
 	logger := zap.NewNop()
-	webhook := NewWebhook("", WithZapLogger(logger))
+	webhook := NewWebhook("", nil, WithZapLogger(logger))
 	assert.Equal(t, logger, webhook.log)
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -6,93 +6,46 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/collectors"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	gcpehttp "github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/http"
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/metrics"
 	"github.com/urfave/negroni"
 	"go.uber.org/zap"
 )
 
 type (
-	// Collectors groups all Prometheus collectors used to exporter Gitlab CI metrics.
-	Collectors struct {
-		IDCollector                       *prometheus.GaugeVec
-		DurationSecondsCollector          *prometheus.GaugeVec
-		QueuedDurationSecondsCollector    *prometheus.GaugeVec
-		RunCountCollector                 *prometheus.CounterVec
-		StatusCollector                   *prometheus.GaugeVec
-		TimestampCollector                *prometheus.GaugeVec
-		JobIDCollector                    *prometheus.GaugeVec
-		JobDurationSecondsCollector       *prometheus.GaugeVec
-		JobQueuedDurationSecondsCollector *prometheus.GaugeVec
-		JobRunCountCollector              *prometheus.CounterVec
-		JobStatusCollector                *prometheus.GaugeVec
-		JobTimestampCollector             *prometheus.GaugeVec
-	}
-
 	Webhook struct {
-		http.Handler
-		Collectors
-
+		metrics.Collectors
+		mux *http.ServeMux
 		log *zap.Logger
 	}
 )
 
 // NewWebhook creates a new instance of the Gitlab event webhook handler.
-func NewWebhook(pattern, secretToken string, opts ...Option) *Webhook {
+func NewWebhook(secretToken string, opts ...Option) *Webhook {
 	webhook := &Webhook{
-		Handler: http.NewServeMux(),
-		Collectors: Collectors{
-			IDCollector:                       collectors.NewCollectorID(),
-			DurationSecondsCollector:          collectors.NewCollectorDurationSeconds(),
-			QueuedDurationSecondsCollector:    collectors.NewCollectorQueuedDurationSeconds(),
-			RunCountCollector:                 collectors.NewCollectorRunCount(),
-			StatusCollector:                   collectors.NewCollectorStatus(),
-			TimestampCollector:                collectors.NewCollectorTimestamp(),
-			JobIDCollector:                    collectors.NewCollectorJobID(),
-			JobDurationSecondsCollector:       collectors.NewCollectorJobDurationSeconds(),
-			JobQueuedDurationSecondsCollector: collectors.NewCollectorJobQueuedDurationSeconds(),
-			JobRunCountCollector:              collectors.NewCollectorJobRunCount(),
-			JobStatusCollector:                collectors.NewCollectorJobStatus(),
-			JobTimestampCollector:             collectors.NewCollectorJobTimestamp(),
-		},
-
-		log: zap.Must(zap.NewProduction()),
+		Collectors: metrics.AllCollectors(),
+		mux:        http.NewServeMux(),
+		log:        zap.Must(zap.NewProduction()),
 	}
-
-	prometheus.MustRegister(
-		webhook.IDCollector,
-		webhook.DurationSecondsCollector,
-		webhook.QueuedDurationSecondsCollector,
-		webhook.RunCountCollector,
-		webhook.StatusCollector,
-		webhook.TimestampCollector,
-		webhook.JobIDCollector,
-		webhook.JobDurationSecondsCollector,
-		webhook.JobQueuedDurationSecondsCollector,
-		webhook.JobRunCountCollector,
-		webhook.JobStatusCollector,
-		webhook.JobTimestampCollector,
-	)
 
 	for _, opt := range opts {
 		opt(webhook)
 	}
 
-	mux := webhook.Handler.(*http.ServeMux)
-	mux.Handle("/healthz", http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+	webhook.mux.Handle("/healthz", http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.WriteHeader(200)
 	}))
 
-	root := negroni.New(NewRecoverMiddleware(webhook.log), NewZapMiddleware(webhook.log))
-	mux.Handle(pattern, root.With(negroni.Wrap(promhttp.Handler())))
-
+	root := negroni.New(gcpehttp.NewRecoverMiddleware(webhook.log), gcpehttp.NewZapMiddleware(webhook.log))
 	gitlab := root.With(NewGitlabSecretTokenMiddleware(secretToken))
-	mux.Handle("/pipeline", gitlab.With(negroni.Wrap(processHandler(webhook.handlePipelineEvent))))
-	mux.Handle("/job", gitlab.With(negroni.Wrap(processHandler(webhook.handleJobEvent))))
+	webhook.mux.Handle("/pipeline", gitlab.With(negroni.Wrap(processHandler(webhook.handlePipelineEvent))))
+	webhook.mux.Handle("/job", gitlab.With(negroni.Wrap(processHandler(webhook.handleJobEvent))))
 
 	return webhook
+}
+
+func (webhook Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	webhook.mux.ServeHTTP(w, r)
 }
 
 // processHandler wraps the event handlers to simplify their usage.
@@ -118,7 +71,7 @@ func processHandler[T any](handler func(event T) error) http.HandlerFunc {
 		if err != nil {
 			// NOTE: we return this status code as recommended by Gitlab
 			writer.WriteHeader(http.StatusBadRequest)
-			_, _ = writer.Write(errToJson(err))
+			gcpehttp.WriteError(writer, err)
 			return
 		}
 
@@ -126,7 +79,7 @@ func processHandler[T any](handler func(event T) error) http.HandlerFunc {
 		if err != nil {
 			// NOTE: we return this status code as recommended by Gitlab
 			writer.WriteHeader(http.StatusBadRequest)
-			_, _ = writer.Write(errToJson(err))
+			gcpehttp.WriteError(writer, err)
 			return
 		}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -14,16 +14,16 @@ import (
 
 type (
 	Webhook struct {
-		metrics.Collectors
-		mux *http.ServeMux
-		log *zap.Logger
+		collectors *metrics.PrometheusCollectors
+		mux        *http.ServeMux
+		log        *zap.Logger
 	}
 )
 
 // NewWebhook creates a new instance of the Gitlab event webhook handler.
-func NewWebhook(secretToken string, opts ...Option) *Webhook {
+func NewWebhook(secretToken string, collectors *metrics.PrometheusCollectors, opts ...Option) *Webhook {
 	webhook := &Webhook{
-		Collectors: metrics.AllCollectors(),
+		collectors: collectors,
 		mux:        http.NewServeMux(),
 		log:        zap.Must(zap.NewProduction()),
 	}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -3,69 +3,129 @@ package webhook
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
+	"net/url"
 	"testing"
 
+	"github.com/radiofrance/gitlab-ci-pipelines-exporter/pkg/metrics"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_processHandler(t *testing.T) {
-	var status atomic.Bool
-	dummy := func(event bool) error {
-		status.Store(event)
+func Test_Webhook_ServeHTTP(t *testing.T) {
+	collectors := metrics.NewPrometheusCollectors()
+	webhook := NewWebhook("secret_token", collectors)
+	server := httptest.NewServer(webhook)
 
-		if event {
-			return fmt.Errorf("dummy error")
-		}
-		return nil
+	authenticatedHeaders := http.Header{
+		"X-Gitlab-Token": {"secret_token"},
 	}
 
 	tcases := map[string]struct {
-		method string
-		event  string
+		method  string
+		uri     string
+		headers map[string][]string
+		event   string
 
-		expectedStatus     bool
-		expectedReturnCode int
+		expectedStatusCode int
 		expectedBody       string
 	}{
-		"event:false": {
-			method:             http.MethodPost,
-			event:              `false`,
-			expectedStatus:     false,
-			expectedReturnCode: http.StatusOK,
-		},
-		"event:true": {
-			method:             http.MethodPost,
-			event:              `true`,
-			expectedStatus:     true,
-			expectedReturnCode: http.StatusBadRequest,
-			expectedBody:       `{"error":"dummy error"}`,
-		},
-		"event:invalid method": {
+		"Healthcheck route responds 200": {
 			method:             http.MethodGet,
-			expectedReturnCode: http.StatusMethodNotAllowed,
+			uri:                "/healthz",
+			expectedStatusCode: http.StatusOK,
 		},
-		"event:invalid event": {
+		"Pipelines route responds 500 when not authenticated": {
 			method:             http.MethodPost,
+			uri:                "/pipeline",
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedBody:       `{"error":"invalid Gitlab webhook secret token"}`,
+		},
+		"Pipelines route responds 200 when authenticated": {
+			method:             http.MethodPost,
+			uri:                "/pipeline",
+			headers:            authenticatedHeaders,
+			event:              `{"foo":"bar"}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		"Pipeline route responds 405 when invalid method": {
+			method:             http.MethodGet,
+			uri:                "/pipeline",
+			headers:            authenticatedHeaders,
+			expectedStatusCode: http.StatusMethodNotAllowed,
+		},
+		"Pipeline route handles invalid event data": {
+			method:             http.MethodPost,
+			uri:                "/pipeline",
+			headers:            authenticatedHeaders,
+			event:              `true`,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"error":"json: cannot unmarshal bool into Go value of type gitlab_events.PipelineEvent"}`,
+		},
+		"Pipeline route handles invalid json payload": {
+			method:             http.MethodPost,
+			uri:                "/pipeline",
+			headers:            authenticatedHeaders,
 			event:              `not a json`,
-			expectedReturnCode: http.StatusBadRequest,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"error":"invalid character 'o' in literal null (expecting 'u')"}`,
+		},
+		"Job route responds 500 when not authenticated": {
+			method:             http.MethodPost,
+			uri:                "/job",
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedBody:       `{"error":"invalid Gitlab webhook secret token"}`,
+		},
+		"Job route responds 200 when authenticated": {
+			method:             http.MethodPost,
+			uri:                "/job",
+			headers:            authenticatedHeaders,
+			event:              `{"foo":"bar"}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		"Job route responds 405 when invalid method": {
+			method:             http.MethodGet,
+			uri:                "/job",
+			headers:            authenticatedHeaders,
+			expectedStatusCode: http.StatusMethodNotAllowed,
+		},
+		"Job route handles invalid event data": {
+			method:             http.MethodPost,
+			uri:                "/job",
+			headers:            authenticatedHeaders,
+			event:              `true`,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"error":"json: cannot unmarshal bool into Go value of type gitlab_events.JobEvent"}`,
+		},
+		"Job route handles invalid json payload": {
+			method:             http.MethodPost,
+			uri:                "/job",
+			headers:            authenticatedHeaders,
+			event:              `not a json`,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       `{"error":"invalid character 'o' in literal null (expecting 'u')"}`,
 		},
 	}
 
 	for name, tcase := range tcases {
 		t.Run(name, func(t *testing.T) {
-			status.Store(false)
-			request := httptest.NewRequest(tcase.method, "http://:0", bytes.NewBuffer([]byte(tcase.event)))
-			writer := httptest.NewRecorder()
+			requestURL, err := url.Parse(fmt.Sprintf("%s%s", server.URL, tcase.uri))
+			require.NoError(t, err)
 
-			processHandler(dummy).ServeHTTP(writer, request)
+			request := httptest.NewRequest(tcase.method, server.URL, bytes.NewBuffer([]byte(tcase.event)))
+			request.RequestURI = ""
+			request.URL = requestURL
+			request.Header = tcase.headers
+			response, err := server.Client().Do(request)
+			require.NoError(t, err)
 
-			assert.Equal(t, tcase.expectedStatus, status.Load())
-			assert.Equal(t, tcase.expectedReturnCode, writer.Code)
-			assert.Equal(t, tcase.expectedBody, writer.Body.String())
+			body, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tcase.expectedStatusCode, response.StatusCode)
+			assert.Equal(t, tcase.expectedBody, string(body))
 		})
 	}
 }


### PR DESCRIPTION
This PR adds a new endpoint for incoming webhooks, on a dedicated port (8080 by default).

This is a breaking change, users must change their webhooks on GitLab project settings to use the new port.

Closes #36