### PR TITLE
make httpProbePath customizable

### DIFF
--- a/charts/gitlab-ci-runner-exporter/templates/deployment.yaml
+++ b/charts/gitlab-ci-runner-exporter/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet: &httpProbe
-              path: /healthz
+              path: /{{ .Values.httpProbePath }}
               port: http
             periodSeconds: 20
             timeoutSeconds: 5

--- a/charts/gitlab-ci-runner-exporter/values.yaml
+++ b/charts/gitlab-ci-runner-exporter/values.yaml
@@ -313,3 +313,5 @@ serviceAccount:
   # serviceAccount.name -- the name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+httpProbePath: /healthz


### PR DESCRIPTION
We need to check /metrics instead of /healthz because the exporter response time increases significantly with time it makes Prometheus times but with this change we can customize the prope endpoint and make Kubernetes restart the pod if it detects that it's timing out.